### PR TITLE
Make gc more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,49 @@
 # gc
 
+gc is a command-line tool to sync activities, workouts, and so on to the Garmin
+Connect service. It is *NOT* an official tool. It mainly targets the Linux as
+Garmin doesn't provide the Connect Launcher for this platform.
+
+## Installation
+
 ```
 git clone https://github.com/phacops/gc.git
 cd gc
 go install
 ```
+
+## Create a configuration file
+
+`gc` will try to locate a configuration file at `$XDG_CONFIG_HOME/gc/config`. It
+should be a valid json file with `gc_username`, `gc_password`, and `watch_dir`
+set. The first two variables are Garmin Connect credentials, the last one is
+where the Garmin device is mounted.
+
+Example:
+```
+{
+  "gc_username":"user@example.com",
+  "gc_password":"aVeryComplexPassword",
+  "watch_dir":"/mnt"
+}
+```
+
+## Usage
+
+`gc` supports syncing activities, workouts, and download updated EPO file. The
+Garmin device must first be mounted.
+
+```
+$ gc sync activities
+syncing ACTIVITY3.FIT... success
+```
+
+You can get more info using the built-in help:
+```
+$ gc --help
+$ gc sync --help
+```
+
+## License
+
+`gc` is released under the MIT license. Please see LICENSE file.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ go install
 
 ## Create a configuration file
 
-`gc` will try to locate a configuration file at `$XDG_CONFIG_HOME/gc/config`. It
+`gc` will try to locate a configuration file at
+```
+${XDG_CONFIG_HOME}/gc/config
+${HOME}/.config/gcrc
+${HOME/.gcrc
+```
 should be a valid json file with `gc_username`, `gc_password`, and `watch_dir`
 set. The first two variables are Garmin Connect credentials, the last one is
 where the Garmin device is mounted.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd gc
 go install
 ```
 
-## Create a configuration file
+## Create a configuration file (optional)
 
 `gc` will try to locate a configuration file at
 ```
@@ -20,9 +20,11 @@ ${XDG_CONFIG_HOME}/gc/config
 ${HOME}/.config/gcrc
 ${HOME/.gcrc
 ```
-should be a valid json file with `gc_username`, `gc_password`, and `watch_dir`
-set. The first two variables are Garmin Connect credentials, the last one is
-where the Garmin device is mounted.
+
+It should be a valid json file. Valid keys are `gc_username`, `gc_password`, and
+`watch_dir`. The first two variables are Garmin Connect credentials, the last
+one is where the Garmin device is mounted. If some of these variables are not
+set, the user will be prompted to type them.
 
 Example:
 ```
@@ -38,10 +40,23 @@ Example:
 `gc` supports syncing activities, workouts, and download updated EPO file. The
 Garmin device must first be mounted.
 
+Without config file:
+```
+$ gc sync activities
+Garmin Connect Username: user@example.com
+Garmin Connect Password: 
+Watch Mount Directory: /mnt
+syncing ACTIVITY1.FIT... success
+```
+
+If you saved your settings in a config file, then no prompt is issued:
 ```
 $ gc sync activities
 syncing ACTIVITY3.FIT... success
 ```
+
+Username and watch mount directory can be overriden with the `--username, -u`
+and `--dir, -d` options respectively.
 
 You can get more info using the built-in help:
 ```

--- a/gc.go
+++ b/gc.go
@@ -17,10 +17,6 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-const (
-	CONFIG_FILE = "${XDG_CONFIG_HOME}/gc/config"
-)
-
 var (
 	EPO_POST_DATA = []byte{10, 45, 10, 7, 101, 120, 112, 114, 101, 115, 115, 18, 5, 100, 101, 95, 68, 69, 26, 7, 87, 105, 110, 100, 111, 119, 115, 34, 18, 54, 48, 49, 32, 83, 101, 114, 118, 105, 99, 101, 32, 80, 97, 99, 107, 32, 49, 18, 10, 8, 140, 180, 147, 184, 14, 18, 0, 24, 0, 24, 28, 34, 0}
 
@@ -178,7 +174,22 @@ func SyncWorkouts(c *cli.Context) {
 }
 
 func main() {
-	configFile, err := os.Open(os.ExpandEnv(CONFIG_FILE))
+	configFiles := []string{
+		"${XDG_CONFIG_HOME}/gc/config",
+		"${HOME)/.config/gcrc",
+		"${HOME}/.gcrc"}
+
+	var configPath string
+	for _, path := range configFiles {
+		path = os.ExpandEnv(path)
+		_, err := os.Stat(path)
+		if err == nil {
+			configPath = path
+			break
+		}
+	}
+
+	configFile, err := os.Open(configPath)
 
 	if err != nil {
 		panic(err)

--- a/gc.go
+++ b/gc.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,16 +11,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/codegangsta/cli"
 	"github.com/phacops/garminconnect"
 	"github.com/satori/go.uuid"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
 	EPO_POST_DATA = []byte{10, 45, 10, 7, 101, 120, 112, 114, 101, 115, 115, 18, 5, 100, 101, 95, 68, 69, 26, 7, 87, 105, 110, 100, 111, 119, 115, 34, 18, 54, 48, 49, 32, 83, 101, 114, 118, 105, 99, 101, 32, 80, 97, 99, 107, 32, 49, 18, 10, 8, 140, 180, 147, 184, 14, 18, 0, 24, 0, 24, 28, 34, 0}
 
-	config Config
+	argUsername      string
+	argWatchDir      string
+	argNoInteractive bool
 )
 
 type Config struct {
@@ -29,7 +33,85 @@ type Config struct {
 	WatchDir              string `json:"watch_dir"`
 }
 
+func setupConfig() *Config {
+	var config Config
+
+	configFiles := []string{
+		"${XDG_CONFIG_HOME}/gc/config",
+		"${HOME)/.config/gcrc",
+		"${HOME}/.gcrc"}
+
+	for _, path := range configFiles {
+		path = os.ExpandEnv(path)
+		_, err := os.Stat(path)
+		if err == nil {
+			configFile, err := os.Open(path)
+
+			if err != nil {
+				panic(err)
+			}
+
+			err = json.NewDecoder(configFile).Decode(&config)
+
+			if err != nil {
+				panic(err)
+			}
+
+			break
+		}
+	}
+
+	if argUsername != "" {
+		config.GarminConnectUsername = argUsername
+	} else if config.GarminConnectUsername == "" && !argNoInteractive {
+		fmt.Print("Garmin Connect Username: ")
+		reader := bufio.NewReader(os.Stdin)
+		username, err := reader.ReadString('\n')
+		if err != nil {
+			panic(err)
+		}
+		config.GarminConnectUsername = strings.TrimSpace(username)
+	}
+
+	if config.GarminConnectPassword == "" && !argNoInteractive {
+		fmt.Print("Garmin Connect Password: ")
+		bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+		fmt.Print("\n")
+		if err != nil {
+			panic(err)
+		}
+		config.GarminConnectPassword = string(bytePassword)
+	}
+
+	if argWatchDir != "" {
+		config.WatchDir = argWatchDir
+	} else if config.WatchDir == "" && !argNoInteractive {
+		fmt.Print("Watch mount directory: ")
+		reader := bufio.NewReader(os.Stdin)
+		watchdir, err := reader.ReadString('\n')
+		if err != nil {
+			panic(err)
+		}
+		config.WatchDir = strings.TrimSpace(watchdir)
+	}
+
+	if config.GarminConnectUsername == "" ||
+		config.GarminConnectPassword == "" ||
+		config.WatchDir == "" {
+		fmt.Fprint(os.Stderr, "Option(s) missing. Aborting.\n")
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(config.WatchDir); err != nil {
+		fmt.Fprintf(os.Stderr, "%s is not a valid mount point for the watch.\n", config.WatchDir)
+		os.Exit(1)
+	}
+
+	return &config
+}
+
 func GetEPOFile(c *cli.Context) {
+	config := setupConfig()
 	client := &http.Client{}
 	request, _ := http.NewRequest("POST", "http://omt.garmin.com/Rce/ProtobufApi/EphemerisService/GetEphemerisData", bytes.NewBuffer(EPO_POST_DATA))
 
@@ -75,6 +157,7 @@ func GetEPOFile(c *cli.Context) {
 }
 
 func SyncActivities(c *cli.Context) {
+	config := setupConfig()
 	client, err := garminconnect.NewClient()
 
 	if err != nil {
@@ -118,6 +201,7 @@ func SyncActivities(c *cli.Context) {
 }
 
 func SyncWorkouts(c *cli.Context) {
+	config := setupConfig()
 	client, err := garminconnect.NewClient()
 
 	if err != nil {
@@ -174,50 +258,26 @@ func SyncWorkouts(c *cli.Context) {
 }
 
 func main() {
-	configFiles := []string{
-		"${XDG_CONFIG_HOME}/gc/config",
-		"${HOME)/.config/gcrc",
-		"${HOME}/.gcrc"}
-
-	var configPath string
-	for _, path := range configFiles {
-		path = os.ExpandEnv(path)
-		_, err := os.Stat(path)
-		if err == nil {
-			configPath = path
-			break
-		}
-	}
-
-	configFile, err := os.Open(configPath)
-
-	if err != nil {
-		panic(err)
-	}
-
-	err = json.NewDecoder(configFile).Decode(&config)
-
-	if err != nil {
-		panic(err)
-	}
-
-	if _, err := os.Stat(config.WatchDir); err != nil {
-		panic(errors.New("you must give a valid path for to the watch"))
-	}
-
 	app := cli.NewApp()
 	app.Name = "gc"
 	app.Usage = "Interact with Garmin Connect"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "username, u",
-			Value: "",
-			Usage: "Garmin Connect username",
+			Name:        "username, u",
+			Value:       "",
+			Usage:       "Garmin Connect username",
+			Destination: &argUsername,
 		},
 		cli.StringFlag{
-			Name:  "dir, d",
-			Value: "/mnt",
-			Usage: "Watch root",
+			Name:        "dir, d",
+			Value:       "",
+			Usage:       "Watch root",
+			Destination: &argWatchDir,
+		},
+		cli.BoolFlag{
+			Name:        "no-interactive",
+			Usage:       "Do not prompt for missing parameters",
+			Destination: &argNoInteractive,
 		},
 	}
 	app.Commands = []cli.Command{

--- a/gc.go
+++ b/gc.go
@@ -215,11 +215,6 @@ func main() {
 			Usage: "Garmin Connect username",
 		},
 		cli.StringFlag{
-			Name:  "password, p",
-			Value: "",
-			Usage: "Garmin Connect password",
-		},
-		cli.StringFlag{
 			Name:  "dir, d",
 			Value: "/mnt",
 			Usage: "Watch root",


### PR DESCRIPTION
This PR intends to give more explicit error messages to people using gc. The goal of the last commit is to allow to use the tool without the need to create a config file.
